### PR TITLE
Add artisan commands for feature flag management

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,29 @@ It is recommended that you only update a features state using the above methods 
 ```
 You should listen for the `FeatureUpdatedEvent` event if you have any downstream implications when a feature state is updated, such as invalidating any cached items that are referenced in dynamic handlers.
 
+### Artisan Commands
+Manage feature flags directly from the command line — useful when SSHed into a server.
+
+#### Interactive Management
+```bash
+php artisan feature:manage
+```
+Displays a table of all features and their states, then lets you select a feature, choose a new state, and confirm before saving. Loops so you can make multiple changes in one session.
+
+#### Scriptable Commands
+```bash
+# Turn a feature on
+php artisan feature:on search-v2
+
+# Turn a feature off
+php artisan feature:off search-v2
+
+# Set a specific state (on, off, dynamic)
+php artisan feature:state search-v2 dynamic
+```
+
+These commands handle cache invalidation automatically and return appropriate exit codes for use in scripts.
+
 ___
 ## Advanced Usage
 ### Dynamic Features

--- a/src/Commands/ManageFeaturesCommand.php
+++ b/src/Commands/ManageFeaturesCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Codinglabs\FeatureFlags\Commands;
+
+use Illuminate\Console\Command;
+use Codinglabs\FeatureFlags\Enums\FeatureState;
+use Codinglabs\FeatureFlags\Facades\FeatureFlag;
+
+class ManageFeaturesCommand extends Command
+{
+    protected $signature = 'feature:manage';
+
+    protected $description = 'Interactively manage feature flags';
+
+    public function handle(): int
+    {
+        $featureModel = config('feature-flags.feature_model');
+
+        $features = $featureModel::all();
+
+        if ($features->isEmpty()) {
+            $this->info('No features found.');
+
+            return self::SUCCESS;
+        }
+
+        while (true) {
+            $this->displayFeaturesTable($features);
+
+            $featureNames = $features->pluck('name')->toArray();
+            $featureNames[] = 'Exit';
+
+            $selected = $this->choice('Select a feature to update', $featureNames);
+
+            if ($selected === 'Exit') {
+                return self::SUCCESS;
+            }
+
+            $states = array_map(fn (FeatureState $state) => $state->value, FeatureState::cases());
+
+            $newState = $this->choice(
+                "Set '{$selected}' to",
+                $states,
+            );
+
+            if ($this->confirm("Set '{$selected}' to '{$newState}'?")) {
+                FeatureFlag::updateFeatureState($selected, FeatureState::from($newState));
+                $this->info("Feature '{$selected}' has been set to '{$newState}'.");
+            }
+
+            $features = $featureModel::all();
+        }
+    }
+
+    private function displayFeaturesTable($features): void
+    {
+        $rows = $features->map(fn ($feature) => [
+            $feature->name,
+            $feature->state->value,
+        ])->toArray();
+
+        $this->table(['Name', 'State'], $rows);
+    }
+}

--- a/src/Commands/SetFeatureStateCommand.php
+++ b/src/Commands/SetFeatureStateCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Codinglabs\FeatureFlags\Commands;
+
+use Illuminate\Console\Command;
+use Codinglabs\FeatureFlags\Enums\FeatureState;
+use Codinglabs\FeatureFlags\Facades\FeatureFlag;
+use Codinglabs\FeatureFlags\Exceptions\MissingFeatureException;
+
+class SetFeatureStateCommand extends Command
+{
+    protected $signature = 'feature:state {name : The feature name} {state : The state to set (on, off, dynamic)}';
+
+    protected $description = 'Set a feature flag to a specific state';
+
+    public function handle(): int
+    {
+        $name = $this->argument('name');
+        $state = $this->argument('state');
+
+        $validStates = array_map(fn (FeatureState $s) => $s->value, FeatureState::cases());
+
+        if (! in_array($state, $validStates)) {
+            $this->error("Invalid state '{$state}'. Valid states: " . implode(', ', $validStates));
+
+            return self::FAILURE;
+        }
+
+        try {
+            FeatureFlag::updateFeatureState($name, FeatureState::from($state));
+        } catch (MissingFeatureException) {
+            $this->error("Feature '{$name}' not found.");
+
+            return self::FAILURE;
+        }
+
+        $this->info("Feature '{$name}' has been set to '{$state}'.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Commands/SetFeatureStateCommand.php
+++ b/src/Commands/SetFeatureStateCommand.php
@@ -21,7 +21,7 @@ class SetFeatureStateCommand extends Command
         $validStates = array_map(fn (FeatureState $s) => $s->value, FeatureState::cases());
 
         if (! in_array($state, $validStates)) {
-            $this->error("Invalid state '{$state}'. Valid states: " . implode(', ', $validStates));
+            $this->error("Invalid state '{$state}'. Valid states: ".implode(', ', $validStates));
 
             return self::FAILURE;
         }

--- a/src/Commands/TurnOffFeatureCommand.php
+++ b/src/Commands/TurnOffFeatureCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Codinglabs\FeatureFlags\Commands;
+
+use Illuminate\Console\Command;
+use Codinglabs\FeatureFlags\Facades\FeatureFlag;
+use Codinglabs\FeatureFlags\Exceptions\MissingFeatureException;
+
+class TurnOffFeatureCommand extends Command
+{
+    protected $signature = 'feature:off {name : The feature name}';
+
+    protected $description = 'Turn off a feature flag';
+
+    public function handle(): int
+    {
+        $name = $this->argument('name');
+
+        try {
+            FeatureFlag::turnOff($name);
+        } catch (MissingFeatureException) {
+            $this->error("Feature '{$name}' not found.");
+
+            return self::FAILURE;
+        }
+
+        $this->info("Feature '{$name}' has been turned off.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Commands/TurnOnFeatureCommand.php
+++ b/src/Commands/TurnOnFeatureCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Codinglabs\FeatureFlags\Commands;
+
+use Illuminate\Console\Command;
+use Codinglabs\FeatureFlags\Facades\FeatureFlag;
+use Codinglabs\FeatureFlags\Exceptions\MissingFeatureException;
+
+class TurnOnFeatureCommand extends Command
+{
+    protected $signature = 'feature:on {name : The feature name}';
+
+    protected $description = 'Turn on a feature flag';
+
+    public function handle(): int
+    {
+        $name = $this->argument('name');
+
+        try {
+            FeatureFlag::turnOn($name);
+        } catch (MissingFeatureException) {
+            $this->error("Feature '{$name}' not found.");
+
+            return self::FAILURE;
+        }
+
+        $this->info("Feature '{$name}' has been turned on.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/FeatureFlagsServiceProvider.php
+++ b/src/FeatureFlagsServiceProvider.php
@@ -6,6 +6,10 @@ use Illuminate\Support\Facades\Blade;
 use Spatie\LaravelPackageTools\Package;
 use Codinglabs\FeatureFlags\Facades\FeatureFlag;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Codinglabs\FeatureFlags\Commands\TurnOnFeatureCommand;
+use Codinglabs\FeatureFlags\Commands\ManageFeaturesCommand;
+use Codinglabs\FeatureFlags\Commands\TurnOffFeatureCommand;
+use Codinglabs\FeatureFlags\Commands\SetFeatureStateCommand;
 
 class FeatureFlagsServiceProvider extends PackageServiceProvider
 {
@@ -14,7 +18,13 @@ class FeatureFlagsServiceProvider extends PackageServiceProvider
         $package
             ->name('laravel-feature-flags')
             ->hasConfigFile()
-            ->hasMigration('create_features_table');
+            ->hasMigration('create_features_table')
+            ->hasCommands([
+                ManageFeaturesCommand::class,
+                TurnOnFeatureCommand::class,
+                TurnOffFeatureCommand::class,
+                SetFeatureStateCommand::class,
+            ]);
     }
 
     public function packageRegistered()

--- a/tests/Commands/ManageFeaturesCommandTest.php
+++ b/tests/Commands/ManageFeaturesCommandTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Codinglabs\FeatureFlags\Models\Feature;
+use Codinglabs\FeatureFlags\Enums\FeatureState;
+use Codinglabs\FeatureFlags\Facades\FeatureFlag;
+
+beforeEach(function () {
+    config([
+        'feature-flags.cache_store' => 'array',
+        'feature-flags.cache_prefix' => 'testing',
+    ]);
+
+    cache()->store('array')->clear();
+});
+
+afterEach(function () {
+    FeatureFlag::reset();
+});
+
+it('shows no features message when none exist', function () {
+    $this->artisan('feature:manage')
+        ->expectsOutput('No features found.')
+        ->assertSuccessful();
+});
+
+it('displays features and allows exiting', function () {
+    Feature::factory()->create([
+        'name' => 'search-v2',
+        'state' => FeatureState::on(),
+    ]);
+
+    $this->artisan('feature:manage')
+        ->expectsTable(['Name', 'State'], [['search-v2', 'on']])
+        ->expectsChoice('Select a feature to update', 'Exit', ['search-v2', 'Exit'])
+        ->assertSuccessful();
+});
+
+it('allows toggling a feature state', function () {
+    Feature::factory()->create([
+        'name' => 'search-v2',
+        'state' => FeatureState::on(),
+    ]);
+
+    $this->artisan('feature:manage')
+        ->expectsTable(['Name', 'State'], [['search-v2', 'on']])
+        ->expectsChoice('Select a feature to update', 'search-v2', ['search-v2', 'Exit'])
+        ->expectsChoice("Set 'search-v2' to", 'off', ['on', 'off', 'dynamic'])
+        ->expectsConfirmation("Set 'search-v2' to 'off'?", 'yes')
+        ->expectsOutput("Feature 'search-v2' has been set to 'off'.")
+        ->expectsTable(['Name', 'State'], [['search-v2', 'off']])
+        ->expectsChoice('Select a feature to update', 'Exit', ['search-v2', 'Exit'])
+        ->assertSuccessful();
+
+    expect(FeatureFlag::getState('search-v2'))->toBe(FeatureState::off());
+});
+
+it('does not update when confirmation is declined', function () {
+    Feature::factory()->create([
+        'name' => 'search-v2',
+        'state' => FeatureState::on(),
+    ]);
+
+    $this->artisan('feature:manage')
+        ->expectsTable(['Name', 'State'], [['search-v2', 'on']])
+        ->expectsChoice('Select a feature to update', 'search-v2', ['search-v2', 'Exit'])
+        ->expectsChoice("Set 'search-v2' to", 'off', ['on', 'off', 'dynamic'])
+        ->expectsConfirmation("Set 'search-v2' to 'off'?", 'no')
+        ->expectsTable(['Name', 'State'], [['search-v2', 'on']])
+        ->expectsChoice('Select a feature to update', 'Exit', ['search-v2', 'Exit'])
+        ->assertSuccessful();
+
+    expect(FeatureFlag::getState('search-v2'))->toBe(FeatureState::on());
+});

--- a/tests/Commands/SetFeatureStateCommandTest.php
+++ b/tests/Commands/SetFeatureStateCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Codinglabs\FeatureFlags\Models\Feature;
+use Codinglabs\FeatureFlags\Enums\FeatureState;
+use Codinglabs\FeatureFlags\Facades\FeatureFlag;
+
+beforeEach(function () {
+    config([
+        'feature-flags.cache_store' => 'array',
+        'feature-flags.cache_prefix' => 'testing',
+    ]);
+
+    cache()->store('array')->clear();
+});
+
+afterEach(function () {
+    FeatureFlag::reset();
+});
+
+it('sets a feature to a specific state', function () {
+    Feature::factory()->create([
+        'name' => 'search-v2',
+        'state' => FeatureState::off(),
+    ]);
+
+    $this->artisan('feature:state', ['name' => 'search-v2', 'state' => 'dynamic'])
+        ->expectsOutput("Feature 'search-v2' has been set to 'dynamic'.")
+        ->assertSuccessful();
+
+    expect(FeatureFlag::getState('search-v2'))->toBe(FeatureState::dynamic());
+});
+
+it('fails with an invalid state', function () {
+    $this->artisan('feature:state', ['name' => 'search-v2', 'state' => 'invalid'])
+        ->expectsOutput("Invalid state 'invalid'. Valid states: on, off, dynamic")
+        ->assertFailed();
+});
+
+it('fails when feature does not exist', function () {
+    $this->artisan('feature:state', ['name' => 'nonexistent', 'state' => 'on'])
+        ->expectsOutput("Feature 'nonexistent' not found.")
+        ->assertFailed();
+});

--- a/tests/Commands/TurnOffFeatureCommandTest.php
+++ b/tests/Commands/TurnOffFeatureCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Codinglabs\FeatureFlags\Models\Feature;
+use Codinglabs\FeatureFlags\Enums\FeatureState;
+use Codinglabs\FeatureFlags\Facades\FeatureFlag;
+
+beforeEach(function () {
+    config([
+        'feature-flags.cache_store' => 'array',
+        'feature-flags.cache_prefix' => 'testing',
+    ]);
+
+    cache()->store('array')->clear();
+});
+
+afterEach(function () {
+    FeatureFlag::reset();
+});
+
+it('turns off a feature', function () {
+    Feature::factory()->create([
+        'name' => 'search-v2',
+        'state' => FeatureState::on(),
+    ]);
+
+    $this->artisan('feature:off', ['name' => 'search-v2'])
+        ->expectsOutput("Feature 'search-v2' has been turned off.")
+        ->assertSuccessful();
+
+    expect(FeatureFlag::getState('search-v2'))->toBe(FeatureState::off());
+});
+
+it('fails when feature does not exist', function () {
+    $this->artisan('feature:off', ['name' => 'nonexistent'])
+        ->expectsOutput("Feature 'nonexistent' not found.")
+        ->assertFailed();
+});

--- a/tests/Commands/TurnOnFeatureCommandTest.php
+++ b/tests/Commands/TurnOnFeatureCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Codinglabs\FeatureFlags\Models\Feature;
+use Codinglabs\FeatureFlags\Enums\FeatureState;
+use Codinglabs\FeatureFlags\Facades\FeatureFlag;
+
+beforeEach(function () {
+    config([
+        'feature-flags.cache_store' => 'array',
+        'feature-flags.cache_prefix' => 'testing',
+    ]);
+
+    cache()->store('array')->clear();
+});
+
+afterEach(function () {
+    FeatureFlag::reset();
+});
+
+it('turns on a feature', function () {
+    Feature::factory()->create([
+        'name' => 'search-v2',
+        'state' => FeatureState::off(),
+    ]);
+
+    $this->artisan('feature:on', ['name' => 'search-v2'])
+        ->expectsOutput("Feature 'search-v2' has been turned on.")
+        ->assertSuccessful();
+
+    expect(FeatureFlag::getState('search-v2'))->toBe(FeatureState::on());
+});
+
+it('fails when feature does not exist', function () {
+    $this->artisan('feature:on', ['name' => 'nonexistent'])
+        ->expectsOutput("Feature 'nonexistent' not found.")
+        ->assertFailed();
+});


### PR DESCRIPTION
## Summary

Re-opened from #5. Originally merged but reverted from main to keep v1.x clean — this is targeted at v2.

- `feature:manage` — interactive table to toggle feature states
- `feature:on` / `feature:off` — turn individual features on/off
- `feature:set` — set a feature to a specific state (on/off/dynamic)

## Test plan

- [ ] Existing tests pass
- [ ] New command tests pass
- [ ] Commands work interactively via `php artisan`